### PR TITLE
Add TransactionStateType to Transaction Table.

### DIFF
--- a/app/TinyBank/Migrations/20210130141313_Add_TransactionStateType_Column.Designer.cs
+++ b/app/TinyBank/Migrations/20210130141313_Add_TransactionStateType_Column.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TinyBank.Core.Data;
 
 namespace TinyBank.Migrations
 {
     [DbContext(typeof(TinyBankDBContext))]
-    partial class TinyBankDBContextModelSnapshot : ModelSnapshot
+    [Migration("20210130141313_Add_TransactionStateType_Column")]
+    partial class Add_TransactionStateType_Column
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/TinyBank/Migrations/20210130141313_Add_TransactionStateType_Column.cs
+++ b/app/TinyBank/Migrations/20210130141313_Add_TransactionStateType_Column.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TinyBank.Migrations
+{
+    public partial class Add_TransactionStateType_Column : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "State",
+                table: "Transaction",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "State",
+                table: "Transaction");
+        }
+    }
+}

--- a/src/TinyBank.Core/Model/Transaction.cs
+++ b/src/TinyBank.Core/Model/Transaction.cs
@@ -11,6 +11,7 @@ namespace TinyBank.Core.Model
         public DateTime Created { get; private set; }
         public TransactionType Type { get; set; }
         public decimal Amount { get; set; }
+        public TransactionStateType State { get; set; } = TransactionStateType.Pending;
 
         public Transaction()
         {

--- a/src/TinyBank.Core/Model/Types/TransactionStateType.cs
+++ b/src/TinyBank.Core/Model/Types/TransactionStateType.cs
@@ -1,0 +1,8 @@
+﻿namespace TinyBank.Core.Model.Types
+{
+    public enum TransactionStateType
+    {
+        Pending = 0,
+        Committed = 1
+    }
+}


### PR DESCRIPTION
Add TransactionStateType to Transaction Table. It can be used by an EOD batch process in order to update accounts balances.